### PR TITLE
Add combobox to select ssl/tsl version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. Download the release under the "release" tab.
 2. Supports Basic Authentication to SMTP server.
 3. Supports Anonymous connection to SMTP Server.
-4. Supports SSL connection to SMTP server.
+4. Supports SSL connection to SMTP server in STARTSSL mode only. Does not support connecting to SMTP/SSL, SMTP over SSL, or SMTPS server on default port 465.
 5. Runs on Windows.
 
 ![Image of Software](https://i.imgur.com/Z7NCEcm.png)

--- a/SimpleSmtpClient/Form1.Designer.cs
+++ b/SimpleSmtpClient/Form1.Designer.cs
@@ -30,6 +30,7 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(mainForm));
             this.serverGroup = new System.Windows.Forms.GroupBox();
+            this.guiUseSsl = new System.Windows.Forms.CheckBox();
             this.guiPassword = new System.Windows.Forms.TextBox();
             this.lblPassword = new System.Windows.Forms.Label();
             this.guiUser = new System.Windows.Forms.TextBox();
@@ -49,13 +50,16 @@
             this.guiEmailFrom = new System.Windows.Forms.TextBox();
             this.lblEmailFrom = new System.Windows.Forms.Label();
             this.guiSendMail = new System.Windows.Forms.Button();
-            this.guiUseSsl = new System.Windows.Forms.CheckBox();
+            this.cmbSSLVersion = new System.Windows.Forms.ComboBox();
+            this.lblSSLVersion = new System.Windows.Forms.Label();
             this.serverGroup.SuspendLayout();
             this.emailGroup.SuspendLayout();
             this.SuspendLayout();
             // 
             // serverGroup
             // 
+            this.serverGroup.Controls.Add(this.lblSSLVersion);
+            this.serverGroup.Controls.Add(this.cmbSSLVersion);
             this.serverGroup.Controls.Add(this.guiUseSsl);
             this.serverGroup.Controls.Add(this.guiPassword);
             this.serverGroup.Controls.Add(this.lblPassword);
@@ -73,13 +77,23 @@
             this.serverGroup.TabStop = false;
             this.serverGroup.Text = "SMTP Configuration";
             // 
+            // guiUseSsl
+            // 
+            this.guiUseSsl.AutoSize = true;
+            this.guiUseSsl.Location = new System.Drawing.Point(25, 97);
+            this.guiUseSsl.Name = "guiUseSsl";
+            this.guiUseSsl.Size = new System.Drawing.Size(68, 17);
+            this.guiUseSsl.TabIndex = 6;
+            this.guiUseSsl.Text = "Use SSL";
+            this.guiUseSsl.UseVisualStyleBackColor = true;
+            // 
             // guiPassword
             // 
             this.guiPassword.Location = new System.Drawing.Point(434, 66);
             this.guiPassword.Name = "guiPassword";
             this.guiPassword.ReadOnly = true;
             this.guiPassword.Size = new System.Drawing.Size(87, 20);
-            this.guiPassword.TabIndex = 8;
+            this.guiPassword.TabIndex = 5;
             // 
             // lblPassword
             // 
@@ -96,7 +110,7 @@
             this.guiUser.Name = "guiUser";
             this.guiUser.ReadOnly = true;
             this.guiUser.Size = new System.Drawing.Size(154, 20);
-            this.guiUser.TabIndex = 6;
+            this.guiUser.TabIndex = 4;
             // 
             // lblUserName
             // 
@@ -113,7 +127,7 @@
             this.guiUseCredentials.Location = new System.Drawing.Point(25, 69);
             this.guiUseCredentials.Name = "guiUseCredentials";
             this.guiUseCredentials.Size = new System.Drawing.Size(116, 17);
-            this.guiUseCredentials.TabIndex = 4;
+            this.guiUseCredentials.TabIndex = 3;
             this.guiUseCredentials.Text = "Use Authentication";
             this.guiUseCredentials.UseVisualStyleBackColor = true;
             this.guiUseCredentials.CheckedChanged += new System.EventHandler(this.guiUseCredentials_CheckedChanged);
@@ -123,7 +137,7 @@
             this.guiPort.Location = new System.Drawing.Point(449, 28);
             this.guiPort.Name = "guiPort";
             this.guiPort.Size = new System.Drawing.Size(73, 20);
-            this.guiPort.TabIndex = 3;
+            this.guiPort.TabIndex = 2;
             // 
             // lblPort
             // 
@@ -173,7 +187,7 @@
             this.guiEmailBody.Multiline = true;
             this.guiEmailBody.Name = "guiEmailBody";
             this.guiEmailBody.Size = new System.Drawing.Size(446, 77);
-            this.guiEmailBody.TabIndex = 8;
+            this.guiEmailBody.TabIndex = 11;
             // 
             // lblBody
             // 
@@ -189,7 +203,7 @@
             this.guiEmailSubject.Location = new System.Drawing.Point(76, 104);
             this.guiEmailSubject.Name = "guiEmailSubject";
             this.guiEmailSubject.Size = new System.Drawing.Size(446, 20);
-            this.guiEmailSubject.TabIndex = 6;
+            this.guiEmailSubject.TabIndex = 10;
             // 
             // lblSubject
             // 
@@ -205,7 +219,7 @@
             this.guiEmailTo.Location = new System.Drawing.Point(76, 66);
             this.guiEmailTo.Name = "guiEmailTo";
             this.guiEmailTo.Size = new System.Drawing.Size(446, 20);
-            this.guiEmailTo.TabIndex = 4;
+            this.guiEmailTo.TabIndex = 9;
             // 
             // lblEmailTo
             // 
@@ -221,7 +235,7 @@
             this.guiEmailFrom.Location = new System.Drawing.Point(76, 28);
             this.guiEmailFrom.Name = "guiEmailFrom";
             this.guiEmailFrom.Size = new System.Drawing.Size(446, 20);
-            this.guiEmailFrom.TabIndex = 2;
+            this.guiEmailFrom.TabIndex = 8;
             // 
             // lblEmailFrom
             // 
@@ -237,20 +251,33 @@
             this.guiSendMail.Location = new System.Drawing.Point(446, 427);
             this.guiSendMail.Name = "guiSendMail";
             this.guiSendMail.Size = new System.Drawing.Size(104, 31);
-            this.guiSendMail.TabIndex = 2;
+            this.guiSendMail.TabIndex = 12;
             this.guiSendMail.Text = "Send Mail";
             this.guiSendMail.UseVisualStyleBackColor = true;
             this.guiSendMail.Click += new System.EventHandler(this.guiSendMail_Click);
             // 
-            // guiUseSsl
+            // cmbSSLVersion
             // 
-            this.guiUseSsl.AutoSize = true;
-            this.guiUseSsl.Location = new System.Drawing.Point(25, 97);
-            this.guiUseSsl.Name = "guiUseSsl";
-            this.guiUseSsl.Size = new System.Drawing.Size(68, 17);
-            this.guiUseSsl.TabIndex = 9;
-            this.guiUseSsl.Text = "Use SSL";
-            this.guiUseSsl.UseVisualStyleBackColor = true;
+            this.cmbSSLVersion.FormattingEnabled = true;
+            this.cmbSSLVersion.Items.AddRange(new object[] {
+            "Auto",
+            "SSL3",
+            "TLS 1.0",
+            "TLS 1.1",
+            "TLS 1.2"});
+            this.cmbSSLVersion.Location = new System.Drawing.Point(400, 95);
+            this.cmbSSLVersion.Name = "cmbSSLVersion";
+            this.cmbSSLVersion.Size = new System.Drawing.Size(121, 21);
+            this.cmbSSLVersion.TabIndex = 7;
+            // 
+            // lblSSLVersion
+            // 
+            this.lblSSLVersion.AutoSize = true;
+            this.lblSSLVersion.Location = new System.Drawing.Point(298, 98);
+            this.lblSSLVersion.Name = "lblSSLVersion";
+            this.lblSSLVersion.Size = new System.Drawing.Size(96, 13);
+            this.lblSSLVersion.TabIndex = 10;
+            this.lblSSLVersion.Text = "SSL / TLS Version";
             // 
             // mainForm
             // 
@@ -296,6 +323,8 @@
         private System.Windows.Forms.Label lblEmailFrom;
         private System.Windows.Forms.Button guiSendMail;
         private System.Windows.Forms.CheckBox guiUseSsl;
+        private System.Windows.Forms.Label lblSSLVersion;
+        private System.Windows.Forms.ComboBox cmbSSLVersion;
     }
 }
 

--- a/SimpleSmtpClient/Form1.cs
+++ b/SimpleSmtpClient/Form1.cs
@@ -44,6 +44,29 @@ namespace SimpleSmtpClient
                 if (guiUseSsl.Checked)
                 {
                     client.EnableSsl = true;
+
+                    int sslVer = cmbSSLVersion.SelectedIndex;
+                    if (sslVer == 0 || sslVer == -1)
+                    {
+                        System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.SystemDefault;
+                    }
+                    else if (sslVer == 1)
+                    {
+                        System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3;
+                    }
+                    else if (sslVer == 2)
+                    {
+                        System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
+                    }
+                    else if (sslVer == 3)
+                    {
+                        System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
+                    }
+                    else if (sslVer == 4)
+                    {
+                        System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+                    }
+                    //tls 1.3 not supported by .net framework 4.8 as of now.
                 }
                 MailMessage message = CreateMailMessage();
                 client.Send(message);

--- a/SimpleSmtpClient/Form1.resx
+++ b/SimpleSmtpClient/Form1.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAkAAAAAAAEAIABWTgAAlgAAAICAAAABACAAKAgBAOxOAABgYAAAAQAgAKiUAAAUVwEASEgAAAEA

--- a/SimpleSmtpClient/Properties/AssemblyInfo.cs
+++ b/SimpleSmtpClient/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/SimpleSmtpClient/Properties/Resources.Designer.cs
+++ b/SimpleSmtpClient/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace SimpleSmtpClient.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/SimpleSmtpClient/Properties/Settings.Designer.cs
+++ b/SimpleSmtpClient/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SimpleSmtpClient.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/SimpleSmtpClient/SimpleSmtpClient.csproj
+++ b/SimpleSmtpClient/SimpleSmtpClient.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SimpleSmtpClient</RootNamespace>
     <AssemblyName>SimpleSmtpClient</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/SimpleSmtpClient/app.config
+++ b/SimpleSmtpClient/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
Upgrade to .net framework 4.8
Add combobox to select ssl/tsl version.
Note that .net SmtpClient only support server with STARTTSL and does not support native SMTPS
https://docs.microsoft.com/en-us/dotnet/api/system.net.mail.smtpclient.enablessl?view=net-6.0